### PR TITLE
Bugfix intersect collapsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ With version 2, it is not possible anymore to provide the insert sizes via the `
 
 * 2.2.2
 
-  * Bugfix in `intersectCollapsing.py`: Produced columns with `set()` output and lines were put out instead of withheld, resulting in alignment errors in subsequent unchecked paste commands. Bug was fixed, script refactored and Python 3 type hints employed.
+  * Bugfix in `intersectionCollapsing.py`: Produced columns with `set()` output and lines were put out instead of withheld, resulting in alignment errors in subsequent unchecked paste commands. Bug was fixed, script refactored and Python 3 type hints employed (not enforced by Python, though).
   * Added `safe_paste.py` to shield against similar bugs in the future
   * Added basic check to shield against yet unfixed potential unnoticable IO-errors in sophia binary (see [Bitbucket PR](https://bitbucket.org/utoprak/sophia/pull-requests/2/safer-file-io/diff))
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ With version 2, it is not possible anymore to provide the insert sizes via the `
 
 ## Change Log
 
+* 2.2.1
+
+  * Bugfix: intersectionCollapsing.py produces empty output instead of dot-line on empty input. Avoid downsteam int-cast error
+
 * 2.2.0
 
   * Fix ignoring of `sophiaOutputDirectory` for `$sampleType_$pid_bps_annotatedAbridged.bedpe.WARNINGS` file resulting in wrong location of the file

--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ With version 2, it is not possible anymore to provide the insert sizes via the `
 
 ## Change Log
 
-* 2.2.1
+* 2.2.2
 
-  * Bugfix: intersectionCollapsing.py produces empty output instead of dot-line on empty input. Avoid downsteam int-cast error
+  * Bugfix in `intersectCollapsing.py`: Produced columns with `set()` output and lines were put out instead of withheld, resulting in alignment errors in subsequent unchecked paste commands. Bug was fixed, script refactored and Python 3 type hints employed.
+  * Added `safe_paste.py` to shield against similar bugs in the future
+  * Added basic check to shield against yet unfixed potential unnoticable IO-errors in sophia binary (see [Bitbucket PR](https://bitbucket.org/utoprak/sophia/pull-requests/2/safer-file-io/diff))
+
+* 2.2.1 (deprecated)
+
+  * Bugfix: `intersectionCollapsing.py` produces empty output instead of dot-line on empty input. Avoid downsteam int-cast error
 
 * 2.2.0
 

--- a/SophiaWorkflow.iml
+++ b/SophiaWorkflow.iml
@@ -2,7 +2,7 @@
 <module type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Python" name="Python">
-      <configuration sdkName="Python 3.6 (SophiaWorkflow)" />
+      <configuration sdkName="Python 3.7 (base)" />
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
@@ -17,13 +17,11 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="PluginBase" />
-    <orderEntry type="library" name="R User Library" level="project" />
-    <orderEntry type="library" name="R Skeletons" level="application" />
     <orderEntry type="library" name="Gradle: org.codehaus.groovy:groovy-all:2.4.9" level="project" />
     <orderEntry type="module" module-name="Roddy" />
     <orderEntry type="module" module-name="RoddyToolLib" />
-    <orderEntry type="library" name="Python 3.6 (SophiaWorkflow) interpreter library" level="application" />
-    <orderEntry type="module" module-name="COWorkflowsBasePlugin" />
+    <orderEntry type="module" module-name="COWorkflowsBasePlugin_1.4.0" />
+    <orderEntry type="module" module-name="PluginBase" />
+    <orderEntry type="library" name="Python 3.7 (base) interpreter library" level="application" />
   </component>
 </module>

--- a/resources/analysisTools/sophiaworkflow/RNAdecontaminationStep2.py
+++ b/resources/analysisTools/sophiaworkflow/RNAdecontaminationStep2.py
@@ -51,7 +51,7 @@ with open(preFilteredBedpe) as inputHandle:
         if line[0] != '#':
             lineIndex += 1
             skipLine = False
-            if lineIndex not in lineIndices:
+            if lineIndex not in sorted(list(lineIndices)):
                 lineChunks = line.rstrip().split('\t')
                 eventType = lineChunks[8]
                 eventScore = int(lineChunks[9])

--- a/resources/analysisTools/sophiaworkflow/fusionCandidates.py
+++ b/resources/analysisTools/sophiaworkflow/fusionCandidates.py
@@ -16,6 +16,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+#
+# Add the columns "directFusionCandidates", "directFusionCandidatesBothCancer",
+# "indirectFusionCandidatesLeftCancerRightAny", "indirectFusionCandidatesRightCancerLeftAny",
+# and "indirectFusionCandidatesAny" to the input TSV.
+#
+# Note that some output fields only contain the first gene name from a list in one of the input colums. If these
+# input lists have quasi random order (e.g. being just the random-ordered fields of a dictionary) then these
+# columns may appear to contain unpredictable values -- in particular different values for different runs
+# of the workflow.
+#
 import fileinput
 import re
 import itertools
@@ -54,7 +64,7 @@ def getDirectFusion(gene1Raw, gene2Raw):
         if rawName1 == rawName2:
             fusionList.append(x)
         else:
-            fusionList.append([rawName1, rawName2])
+            fusionList.append((rawName1, rawName2))
     sortedFusions = set()
     filteredFusionList = list()
     fusionCandidates = list()
@@ -74,7 +84,7 @@ def getDirectFusion(gene1Raw, gene2Raw):
             if fusion[0] != fusion[1]:
                 fusionCandidates.append('-'.join(fusion))
         if len(fusionCandidates) > 0:
-            return ','.join(fusionCandidates)
+            return ','.join(sorted(fusionCandidates))
         else:
             return "."
     else:

--- a/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
+++ b/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
@@ -21,7 +21,7 @@ from sys import argv
 inputFile = argv[1]
 
 
-def print_line(hit_str, cancer_hit_str, super_enhancer_hit_str):
+def print_line(hit_str: str, cancer_hit_str: str, super_enhancer_hit_str: str):
     """Print a line of information unless it is trivial/all '.'"""
     if hit_str != "." or cancer_hit_str != "." or super_enhancer_hit_str != ".":
         print(hit_str, cancer_hit_str, super_enhancer_hit_str, sep='\t')
@@ -46,7 +46,7 @@ with open(inputFile) as f:
                     cancerHitStr = ','.join(cancerGeneHits)
                 if len(superEnhancerHits) != 0:
                     superEnhancerHitStr = ','.join(superEnhancerHits)
-                print_line(hitStr, cancerHitStr, superEnhancerHits)
+                print_line(hitStr, cancerHitStr, superEnhancerHitStr)
             lastID = ID
             geneHits = set()
             cancerGeneHits = set()

--- a/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
+++ b/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
@@ -15,56 +15,73 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+#
+#
+# Aggregate all annotations for rows with the same ID column value (1-based: column 4).
+# Groups containing no information (no genes, cancer genes, or super-enhancers) are
+# *not* printed.
+#
+# Usage:
+#         intersectionCollapsing.py ${name}directHits[12]Pre
+#
+# The input file comes from bedtools intersect. See sophiaAnnotateAbridgedCaller.sh for details..
+#
 from sys import argv
 
-inputFile = argv[1]
+
+def set_join(the_set: set, sep=",", default="."):
+    if len(the_set) != 0:
+        return sep.join(the_set)
+    else:
+        return default
 
 
-def print_line(hit_str: str, cancer_hit_str: str, super_enhancer_hit_str: str):
+def print_line(gene_hit_string: str, cancer_hit_str: str, super_enhancer_hit_str: str):
     """Print a line of information unless it is trivial/all '.'"""
-    if hit_str != "." or cancer_hit_str != "." or super_enhancer_hit_str != ".":
-        print(hit_str, cancer_hit_str, super_enhancer_hit_str, sep='\t')
+    if gene_hit_string != "." or cancer_hit_str != "." or super_enhancer_hit_str != ".":
+        print(gene_hit_string, cancer_hit_str, super_enhancer_hit_str, sep='\t')
+
+
+def print_hits(gene_hits: set, cancer_gene_hits: set, super_enhancer_hits: set):
+    print_line(set_join(gene_hits),
+               set_join(cancer_gene_hits),
+               set_join(super_enhancer_hits))
+
+
+inputFile = argv[1]
 
 
 lastID = ""
 geneHits = set()
 cancerGeneHits = set()
 superEnhancerHits = set()
+
 with open(inputFile) as f:
     for line in f:
         lineChunks = line.rstrip().split('\t')
         ID = lineChunks[3]
+
         if ID != lastID:
+
             if lastID != "":
-                hitStr = "."
-                cancerHitStr = "."
-                superEnhancerHitStr = "."
-                if len(geneHits) != 0:
-                    hitStr = ','.join(geneHits)
-                if len(cancerGeneHits) != 0:
-                    cancerHitStr = ','.join(cancerGeneHits)
-                if len(superEnhancerHits) != 0:
-                    superEnhancerHitStr = ','.join(superEnhancerHits)
-                print_line(hitStr, cancerHitStr, superEnhancerHitStr)
+                print_hits(geneHits, cancerGeneHits, superEnhancerHits)
+
             lastID = ID
             geneHits = set()
             cancerGeneHits = set()
             superEnhancerHits = set()
-        if lineChunks[4] != ".":
-            if lineChunks[4] == "1":
-                geneHits.add(lineChunks[8])
-            elif lineChunks[4] == "2":
-                cancerGeneHits.add(lineChunks[8])
-            elif lineChunks[4] == "3":
-                superEnhancerHits.add(lineChunks[8])
-    hitStr = "."
-    cancerHitStr = "."
-    superEnhancerHitStr = "."
-    if len(geneHits) != 0:
-        hitStr = ','.join(geneHits)
-    if len(cancerGeneHits) != 0:
-        cancerHitStr = ','.join(cancerGeneHits)
-    if len(superEnhancerHits) != 0:
-        superEnhancerHitStr = ','.join(superEnhancerHits)
-    print_line(hitStr, cancerHitStr, superEnhancerHitStr)
+
+        hitClass = lineChunks[4]
+        if hitClass != ".":
+            annotation = lineChunks[8]
+            if hitClass == "1":
+                geneHits.add(annotation)
+            elif hitClass == "2":
+                cancerGeneHits.add(annotation)
+            elif hitClass == "3":
+                superEnhancerHits.add(annotation)
+            else:
+                raise "Unknown hit class (.=unclassified, 1=gene, 2=cancerGene, 3=superEnhancer): '%'".\
+                    format(hitClass)
+
+    print_hits(geneHits, cancerGeneHits, superEnhancerHits)

--- a/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
+++ b/resources/analysisTools/sophiaworkflow/intersectionCollapsing.py
@@ -18,8 +18,6 @@
 #
 #
 # Aggregate all annotations for rows with the same ID column value (1-based: column 4).
-# Groups containing no information (no genes, cancer genes, or super-enhancers) are
-# *not* printed.
 #
 # Usage:
 #         intersectionCollapsing.py ${name}directHits[12]Pre
@@ -36,16 +34,11 @@ def set_join(the_set: set, sep=",", default="."):
         return default
 
 
-def print_line(gene_hit_string: str, cancer_hit_str: str, super_enhancer_hit_str: str):
-    """Print a line of information unless it is trivial/all '.'"""
-    if gene_hit_string != "." or cancer_hit_str != "." or super_enhancer_hit_str != ".":
-        print(gene_hit_string, cancer_hit_str, super_enhancer_hit_str, sep='\t')
-
-
 def print_hits(gene_hits: set, cancer_gene_hits: set, super_enhancer_hits: set):
-    print_line(set_join(gene_hits),
-               set_join(cancer_gene_hits),
-               set_join(super_enhancer_hits))
+    print(set_join(gene_hits),
+          set_join(cancer_gene_hits),
+          set_join(super_enhancer_hits),
+          sep='\t')
 
 
 inputFile = argv[1]

--- a/resources/analysisTools/sophiaworkflow/safe_paste.py
+++ b/resources/analysisTools/sophiaworkflow/safe_paste.py
@@ -1,17 +1,45 @@
 #!/usr/bin/env python
-
+#
+# Copyright (C) 2018 Umut H. Toprak, Matthias Schlesner, Roland Eils and DKFZ Heidelberg
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Similar to coreutils' `paste` but checks that all files indeed have the same number of lines.
+#
+# Usage:
+#
+# safe_paste.py file {file}*
+#
 import sys
 
 
-def assert_same_linenumber(chunks):
+class InputError(Exception):
+
+    def __init__(self, message: str):
+        self.message = message
+
+
+def assert_same_linenumber(chunks: list):
     file_number = len(chunks)
     for file_i in range(file_number):
         chunk = chunks[file_i]
         if len(chunk) != len(chunks[0]):
-            raise AssertionError("Inconsistent number of lines: '{}' vs. '{}'".format(files[0], files[file_i]))
+            raise InputError("Inconsistent number of lines: '{}' vs. '{}'".format(files[0], files[file_i]))
 
 
-def print_chunks(chunks, delimiter):
+def print_chunks(chunks: list, delimiter):
     file_number = len(chunks)
     chunk_size = len(chunks[0])
     for line_offset in range(chunk_size):
@@ -23,31 +51,41 @@ def print_chunks(chunks, delimiter):
         print(result_line)
 
 
-def all_chunks_empty(chunks):
+def all_chunks_empty(chunks: list):
     return all(list(map(lambda chunk: len(chunk) == 0, chunks)))
 
 
-def any_chunk_not_full(chunks, max_chunk_size):
+def any_chunk_not_full(chunks: list, max_chunk_size):
     return any(list(map(lambda chunk: len(chunks) < max_chunk_size, chunks)))
 
 
 files = sys.argv[1:len(sys.argv)]
-max_chunk_size = 1000
-delimiter = "\t"
 
-file_handles = list(map(lambda f: open(f, "r"), files))
+try:
+    if len(files) == 0:
+        raise InputError("Empty argument list. Usage: 'safe_paste.py file {file}*")
 
-while True:
-    chunks = list(map(lambda fh: fh.readlines(max_chunk_size), file_handles))
+    max_chunk_size = 1000
+    delimiter = "\t"
 
-    # For the special case that all files are empty.
-    if all_chunks_empty(chunks):
-        break
+    file_handles = list(map(lambda f: open(f, "r"), files))
 
-    # Otherwise detect inconsistent line-numbers
-    assert_same_linenumber(chunks)
-    print_chunks(chunks, delimiter)
+    while True:
+        chunks = list(map(lambda fh: fh.readlines(max_chunk_size), file_handles))
 
-    # Finally, stop if the last chunk was read (they have all the same non-null lengths according to previous checks)
-    if any_chunk_not_full(chunks, max_chunk_size):
-        break
+        # For the special case that all files are empty.
+        if all_chunks_empty(chunks):
+            break
+
+        # Otherwise detect inconsistent line-numbers
+        assert_same_linenumber(chunks)
+        print_chunks(chunks, delimiter)
+
+        # Stop if the last chunk was read (they have all the same non-null lengths according to previous checks)
+        if any_chunk_not_full(chunks, max_chunk_size):
+            break
+
+except InputError as e:
+    print(e.message, file=sys.stderr)
+    exit(1)
+

--- a/resources/analysisTools/sophiaworkflow/safe_paste.py
+++ b/resources/analysisTools/sophiaworkflow/safe_paste.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+import sys
+
+
+def assert_same_linenumber(chunks):
+    file_number = len(chunks)
+    for file_i in range(file_number):
+        chunk = chunks[file_i]
+        if len(chunk) != len(chunks[0]):
+            raise AssertionError("Inconsistent number of lines: '{}' vs. '{}'".format(files[0], files[file_i]))
+
+
+def print_chunks(chunks, delimiter):
+    file_number = len(chunks)
+    chunk_size = len(chunks[0])
+    for line_offset in range(chunk_size):
+        result_line = ""
+        for file_i in range(file_number):
+            result_line += chunks[file_i][line_offset].rstrip()
+            if file_i != file_number - 1:
+                result_line += delimiter
+        print(result_line)
+
+
+def all_chunks_empty(chunks):
+    return all(list(map(lambda chunk: len(chunk) == 0, chunks)))
+
+
+def any_chunk_not_full(chunks, max_chunk_size):
+    return any(list(map(lambda chunk: len(chunks) < max_chunk_size, chunks)))
+
+
+files = sys.argv[1:len(sys.argv)]
+max_chunk_size = 1000
+delimiter = "\t"
+
+file_handles = list(map(lambda f: open(f, "r"), files))
+
+while True:
+    chunks = list(map(lambda fh: fh.readlines(max_chunk_size), file_handles))
+
+    # For the special case that all files are empty.
+    if all_chunks_empty(chunks):
+        break
+
+    # Otherwise detect inconsistent line-numbers
+    assert_same_linenumber(chunks)
+    print_chunks(chunks, delimiter)
+
+    # Finally, stop if the last chunk was read (they have all the same non-null lengths according to previous checks)
+    if any_chunk_not_full(chunks, max_chunk_size):
+        break

--- a/resources/analysisTools/sophiaworkflow/safe_paste.py
+++ b/resources/analysisTools/sophiaworkflow/safe_paste.py
@@ -88,4 +88,3 @@ try:
 except InputError as e:
     print(e.message, file=sys.stderr)
     exit(1)
-

--- a/resources/analysisTools/sophiaworkflow/sophiaAnnotateAbridgedCaller.sh
+++ b/resources/analysisTools/sophiaworkflow/sophiaAnnotateAbridgedCaller.sh
@@ -90,14 +90,14 @@ ${BEDTOOLS_BINARY} closest -a ${FILE_DUM}rightCoords -b ${geneRefBedCancer} -g $
 ${BEDTOOLS_BINARY} closest -a ${FILE_DUM}rightCoords -b ${geneRefBed} -g ${chromSizesRef} -io -D ref -iu -t first -k 1 | cut -f 8,9 | sed 's/^\t/.\t/' > ${FILE_DUM}genesDownstream2
 ${BEDTOOLS_BINARY} closest -a ${FILE_DUM}rightCoords -b ${geneRefBedCancer} -g ${chromSizesRef} -io -D ref -iu -t first -k 1 | cut -f 8,9 | sed 's/^\t/.\t/' > ${FILE_DUM}genesDownstreamCancer2
 
-paste ${FILE_DUM}lineOrder <(cut -f1,2 ${FILE_DUM}directHits2) ${FILE_DUM}genesUpstream2 ${FILE_DUM}genesUpstreamCancer2 ${FILE_DUM}genesDownstream2 ${FILE_DUM}genesDownstreamCancer2 | sort -V -k1,1 | cut -f2- > ${FILE_DUM}right
+${PYTHON_BINARY} "$TOOL_SAFE_PASTE" ${FILE_DUM}lineOrder <(cut -f1,2 ${FILE_DUM}directHits2) ${FILE_DUM}genesUpstream2 ${FILE_DUM}genesUpstreamCancer2 ${FILE_DUM}genesDownstream2 ${FILE_DUM}genesDownstreamCancer2 | sort -V -k1,1 | cut -f2- > ${FILE_DUM}right
 cut -f3 ${FILE_DUM}directHits1 > ${FILE_DUM}leftSuperEnhancers
-paste ${FILE_DUM}lineOrder <(cut -f3 ${FILE_DUM}directHits2) | sort -V -k1,1 | cut -f2- > ${FILE_DUM}rightSuperEnhancers
-paste ${ABRIDGED_ANNOTATION} <(cut -f1,2 ${FILE_DUM}directHits1) ${FILE_DUM}genesUpstream1 ${FILE_DUM}genesUpstreamCancer1 ${FILE_DUM}genesDownstream1 ${FILE_DUM}genesDownstreamCancer1 ${FILE_DUM}right ${FILE_DUM}leftSuperEnhancers ${FILE_DUM}rightSuperEnhancers > ${FILE_DUM}tadPrep
+${PYTHON_BINARY} "$TOOL_SAFE_PASTE" ${FILE_DUM}lineOrder <(cut -f3 ${FILE_DUM}directHits2) | sort -V -k1,1 | cut -f2- > ${FILE_DUM}rightSuperEnhancers
+${PYTHON_BINARY} "$TOOL_SAFE_PASTE" ${ABRIDGED_ANNOTATION} <(cut -f1,2 ${FILE_DUM}directHits1) ${FILE_DUM}genesUpstream1 ${FILE_DUM}genesUpstreamCancer1 ${FILE_DUM}genesDownstream1 ${FILE_DUM}genesDownstreamCancer1 ${FILE_DUM}right ${FILE_DUM}leftSuperEnhancers ${FILE_DUM}rightSuperEnhancers > ${FILE_DUM}tadPrep
 
 ${PYTHON_BINARY} ${TOOL_INTRACHROMOSOMALEVENTPICKER} ${FILE_DUM}tadPrep | ${BEDTOOLS_BINARY} intersect -a stdin -b ${roadmapEnhancerRefBed} -u | cut -f 4 > ${FILE_DUM}tadWhitelist
 ${PYTHON_BINARY} ${TOOL_TADANNOTATION_SCRIPT} ${FILE_DUM}tadPrep ${FILE_DUM}tadWhitelist ${consensusTadReferenceBed} ${smallEventThreshold} > ${FILE_DUM}tadAnnotations
-paste ${FILE_DUM}tadPrep ${FILE_DUM}tadAnnotations ${ABRIDGED_ANNOTATION}_preRemapCoords > ${ABRIDGED_ANNOTATION_CONTEXT}
+${PYTHON_BINARY} "$TOOL_SAFE_PASTE" ${FILE_DUM}tadPrep ${FILE_DUM}tadAnnotations ${ABRIDGED_ANNOTATION}_preRemapCoords > ${ABRIDGED_ANNOTATION_CONTEXT}
 rm ${ABRIDGED_ANNOTATION}_preRemapCoords
 
 cat <(echo -e ${STANDARDHEADER})  <(cat ${ABRIDGED_ANNOTATION_CONTEXT}) | uniq | ${TOOL_FUSION_CANDIDATES_SCRIPT} > ${BEDPE_RESULT_FILE_FILTERED}

--- a/resources/analysisTools/sophiaworkflow/sophiaAnnotateAbridgedCaller.sh
+++ b/resources/analysisTools/sophiaworkflow/sophiaAnnotateAbridgedCaller.sh
@@ -52,11 +52,11 @@ FILE_DUM=${tumorFileRaw}_dum
 
 if [[ ! -e "${bloodFile}" ]]
 then
-	${SOPHIA_ANNOTATION_BINARY} --tumorresults ${tumorFile} --mref ${mRef} --pidsinmref ${pidsInMref} --bpfreq ${bpFreq} --artifactlofreq ${artifactLoFreq} --artifacthifreq ${artifactHiFreq} --clonalitystrictlofreq ${clonalityStrictLoFreq} --clonalitylofreq ${clonalityLoFreq} --clonalityhifreq ${clonalityHiFreq} --germlineoffset ${germlineFuzziness} --defaultreadlengthtumor ${tumorDefaultReadLength} --germlinedblimit ${germlineDbLimit} \
-	  > ${ABRIDGED_ANNOTATION}Pre
+  ${SOPHIA_ANNOTATION_BINARY} --tumorresults ${tumorFile} --mref ${mRef} --pidsinmref ${pidsInMref} --bpfreq ${bpFreq} --artifactlofreq ${artifactLoFreq} --artifacthifreq ${artifactHiFreq} --clonalitystrictlofreq ${clonalityStrictLoFreq} --clonalitylofreq ${clonalityLoFreq} --clonalityhifreq ${clonalityHiFreq} --germlineoffset ${germlineFuzziness} --defaultreadlengthtumor ${tumorDefaultReadLength} --germlinedblimit ${germlineDbLimit} \
+    > ${ABRIDGED_ANNOTATION}Pre
 else
-	${SOPHIA_ANNOTATION_BINARY} --tumorresults ${tumorFile} --mref ${mRef} --controlresults ${bloodFile} --pidsinmref ${pidsInMref} --bpfreq ${bpFreq} --artifactlofreq ${artifactLoFreq} --artifacthifreq ${artifactHiFreq} --clonalitystrictlofreq ${clonalityStrictLoFreq} --clonalitylofreq ${clonalityLoFreq} --clonalityhifreq ${clonalityHiFreq} --germlineoffset ${germlineFuzziness} --defaultreadlengthtumor ${tumorDefaultReadLength} --defaultreadlengthcontrol ${controlDefaultReadLength} --germlinedblimit ${germlineDbLimit} \
-	  > ${ABRIDGED_ANNOTATION}Pre
+  ${SOPHIA_ANNOTATION_BINARY} --tumorresults ${tumorFile} --mref ${mRef} --controlresults ${bloodFile} --pidsinmref ${pidsInMref} --bpfreq ${bpFreq} --artifactlofreq ${artifactLoFreq} --artifacthifreq ${artifactHiFreq} --clonalitystrictlofreq ${clonalityStrictLoFreq} --clonalitylofreq ${clonalityLoFreq} --clonalityhifreq ${clonalityHiFreq} --germlineoffset ${germlineFuzziness} --defaultreadlengthtumor ${tumorDefaultReadLength} --defaultreadlengthcontrol ${controlDefaultReadLength} --germlinedblimit ${germlineDbLimit} \
+    > ${ABRIDGED_ANNOTATION}Pre
 fi
 
 grepIgnoreEmpty $'^#' ${ABRIDGED_ANNOTATION}Pre | grepIgnoreEmpty -v $'^##' > ${ABRIDGED_ANNOTATION}.WARNINGS
@@ -109,31 +109,31 @@ ${PYTHON_BINARY} ${TOOL_RNACONT_DEL_COUNTER_SCRIPT} ${MERGED_DELEXTRACTINTERSECT
 MERGED_RNA_CONTAMINATED_GENES="`grepIgnoreEmpty -v locus ${MERGED_RNACONTCANDIDATES_MORETHAN2INTRONS} | wc -l`"
 if [[ "${MERGED_RNA_CONTAMINATED_GENES}" -ge "11" ]]
 then
-	mv ${BEDPE_RESULT_FILE_FILTERED} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue
-	${PYTHON_BINARY} ${TOOL_RNADECONT_STEP1_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue | ${BEDTOOLS_BINARY} intersect -f 0.9 -r -a stdin -b ${spliceJunctionsRefBed} -wa | cut -f4 | uniq > ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices
-	${PYTHON_BINARY} ${TOOL_RNADECONT_STEP2_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices > ${BEDPE_RESULT_FILE_FILTERED}
-	rm ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices
-	echo "#${MERGED_RNA_CONTAMINATED_GENES} are affected by RNA contamination, RNA decontamination applied, expect losses and false positives!" >> ${ABRIDGED_ANNOTATION}.WARNINGS
+  mv ${BEDPE_RESULT_FILE_FILTERED} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue
+  ${PYTHON_BINARY} ${TOOL_RNADECONT_STEP1_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue | ${BEDTOOLS_BINARY} intersect -f 0.9 -r -a stdin -b ${spliceJunctionsRefBed} -wa | cut -f4 | uniq > ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices
+  ${PYTHON_BINARY} ${TOOL_RNADECONT_STEP2_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED}.preRnaRescue ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices > ${BEDPE_RESULT_FILE_FILTERED}
+  rm ${BEDPE_RESULT_FILE_FILTERED}.contaminatedIndices
+  echo "#${MERGED_RNA_CONTAMINATED_GENES} are affected by RNA contamination, RNA decontamination applied, expect losses and false positives!" >> ${ABRIDGED_ANNOTATION}.WARNINGS
 fi
 
 ${PYTHON_BINARY} ${TOOL_DEDUP_RESULTS_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED} ${tumorDefaultReadLength} > ${BEDPE_RESULT_FILE_FILTERED_DEDUP}
 
 if [[ -e "$bloodFile" ]]
 then
-	cat <(head -n 1 ${BEDPE_RESULT_FILE_FILTERED})  <(grepIgnoreEmpty GERMLINE ${BEDPE_RESULT_FILE_FILTERED}) | uniq > ${BEDPE_RESULT_FILE_FILTERED_GERMLINE}
-	grepIgnoreEmpty -v GERMLINE ${BEDPE_RESULT_FILE_FILTERED}  > ${BEDPE_RESULT_FILE_FILTERED_SOMATIC}
-	
-	cat <(head -n 1 ${BEDPE_RESULT_FILE_FILTERED_DEDUP})  <(grepIgnoreEmpty GERMLINE ${BEDPE_RESULT_FILE_FILTERED_DEDUP}) | uniq > ${BEDPE_RESULT_FILE_FILTERED_DEDUP_GERMLINE}
-	grepIgnoreEmpty -v GERMLINE ${BEDPE_RESULT_FILE_FILTERED_DEDUP}  > ${BEDPE_RESULT_FILE_FILTERED_DEDUP_SOMATIC}
-	
-	awk '$10>2' ${BEDPE_RESULT_FILE_FILTERED_SOMATIC} > ${BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ}
-	set +e
-	${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED_SOMATIC} "'${project}:${pid}(somatic)'" "$circlizeScoreThreshold"
-	${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED_GERMLINE} "'${project}:${pid}(germline)'" "$circlizeScoreThreshold"
-	${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED} "'${project}:${pid}(g&s)'" "$circlizeScoreThreshold"
-	set -e
+  cat <(head -n 1 ${BEDPE_RESULT_FILE_FILTERED})  <(grepIgnoreEmpty GERMLINE ${BEDPE_RESULT_FILE_FILTERED}) | uniq > ${BEDPE_RESULT_FILE_FILTERED_GERMLINE}
+  grepIgnoreEmpty -v GERMLINE ${BEDPE_RESULT_FILE_FILTERED}  > ${BEDPE_RESULT_FILE_FILTERED_SOMATIC}
 
-	mv "$BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ" "${BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ/.tmp/}"
+  cat <(head -n 1 ${BEDPE_RESULT_FILE_FILTERED_DEDUP})  <(grepIgnoreEmpty GERMLINE ${BEDPE_RESULT_FILE_FILTERED_DEDUP}) | uniq > ${BEDPE_RESULT_FILE_FILTERED_DEDUP_GERMLINE}
+  grepIgnoreEmpty -v GERMLINE ${BEDPE_RESULT_FILE_FILTERED_DEDUP}  > ${BEDPE_RESULT_FILE_FILTERED_DEDUP_SOMATIC}
+
+  awk '$10>2' ${BEDPE_RESULT_FILE_FILTERED_SOMATIC} > ${BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ}
+  set +e
+  ${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED_SOMATIC} "'${project}:${pid}(somatic)'" "$circlizeScoreThreshold"
+  ${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED_GERMLINE} "'${project}:${pid}(germline)'" "$circlizeScoreThreshold"
+  ${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED} "'${project}:${pid}(g&s)'" "$circlizeScoreThreshold"
+  set -e
+
+  mv "$BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ" "${BEDPE_RESULT_FILE_FILTERED_SOMATIC_ACESEQ/.tmp/}"
   mv "$BEDPE_RESULT_FILE_FILTERED_SOMATIC" "${BEDPE_RESULT_FILE_FILTERED_SOMATIC/.tmp/}"
   mv "$BEDPE_RESULT_FILE_FILTERED_DEDUP_SOMATIC" "${BEDPE_RESULT_FILE_FILTERED_DEDUP_SOMATIC/.tmp/}"
   mv "$BEDPE_RESULT_FILE_FILTERED_GERMLINE" "${BEDPE_RESULT_FILE_FILTERED_GERMLINE/.tmp/}"
@@ -141,19 +141,19 @@ then
   mv "$BEDPE_RESULT_FILE_FILTERED_SOMATIC_OVERHANG_CANDIDATES" "${BEDPE_RESULT_FILE_FILTERED_SOMATIC_OVERHANG_CANDIDATES/.tmp/}"
 
   pdfunite \
-	  "${BEDPE_RESULT_FILE_FILTERED_SOMATIC}_score_${circlizeScoreThreshold}_scaled.pdf" \
-	  "${BEDPE_RESULT_FILE_FILTERED_GERMLINE}_score_${circlizeScoreThreshold}_scaled.pdf" \
-	  "${BEDPE_RESULT_FILE_FILTERED}_score_${circlizeScoreThreshold}_scaled.pdf" \
-	  "${BEDPE_RESULT_FILE_FILTERED_PDF}"
+    "${BEDPE_RESULT_FILE_FILTERED_SOMATIC}_score_${circlizeScoreThreshold}_scaled.pdf" \
+    "${BEDPE_RESULT_FILE_FILTERED_GERMLINE}_score_${circlizeScoreThreshold}_scaled.pdf" \
+    "${BEDPE_RESULT_FILE_FILTERED}_score_${circlizeScoreThreshold}_scaled.pdf" \
+    "${BEDPE_RESULT_FILE_FILTERED_PDF}"
 
 else
-	awk '$10>2' ${BEDPE_RESULT_FILE_FILTERED} > ${BEDPE_RESULT_FILE_FILTERED_ACESEQ}
+  awk '$10>2' ${BEDPE_RESULT_FILE_FILTERED} > ${BEDPE_RESULT_FILE_FILTERED_ACESEQ}
 
-	set +e
-	${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED} "'${project}:${pid}(g&s)'" "$circlizeScoreThreshold"
-	set -e
+  set +e
+  ${RSCRIPT_BINARY} ${TOOL_CIRCLIZE_SCRIPT} ${BEDPE_RESULT_FILE_FILTERED} "'${project}:${pid}(g&s)'" "$circlizeScoreThreshold"
+  set -e
 
-	mv "$BEDPE_RESULT_FILE_FILTERED_ACESEQ" "${BEDPE_RESULT_FILE_FILTERED_ACESEQ/.tmp/}"
+  mv "$BEDPE_RESULT_FILE_FILTERED_ACESEQ" "${BEDPE_RESULT_FILE_FILTERED_ACESEQ/.tmp/}"
   mv "${BEDPE_RESULT_FILE_FILTERED}_score_${circlizeScoreThreshold}_scaled.pdf" "$BEDPE_RESULT_FILE_FILTERED_PDF"
 fi
 
@@ -169,7 +169,7 @@ controlMassiveInvPrefilteringLevel=0
 tumorMassiveInvFilteringLevel=0
 if [[ "`grepIgnoreEmpty controlMassiveInvPrefilteringLevel ${ABRIDGED_ANNOTATION}.WARNINGS | wc -l`" != "0" ]]
 then
-	controlMassiveInvPrefilteringLevel=`grepIgnoreEmpty controlMassiveInvPrefilteringLevel ${ABRIDGED_ANNOTATION}.WARNINGS | cut -f 2`
+  controlMassiveInvPrefilteringLevel=`grepIgnoreEmpty controlMassiveInvPrefilteringLevel ${ABRIDGED_ANNOTATION}.WARNINGS | cut -f 2`
 fi
 
 if [[ "`grepIgnoreEmpty tumorMassiveInvFilteringLevel ${ABRIDGED_ANNOTATION}.WARNINGS | wc -l`" != "0" ]]
@@ -213,7 +213,7 @@ if [[ ! -v DEBUG_SOPHIA || ( $DEBUG_SOPHIA -ne 1 && $(echo "$DEBUG_SOPHIA" | tr 
 
   # QC Files
   rm -f "${BEDPE_RESULT_FILE_FILTERED_SOMATIC}_score_${circlizeScoreThreshold}_scaled.pdf"
-	rm -f "${BEDPE_RESULT_FILE_FILTERED_GERMLINE}_score_${circlizeScoreThreshold}_scaled.pdf"
+  rm -f "${BEDPE_RESULT_FILE_FILTERED_GERMLINE}_score_${circlizeScoreThreshold}_scaled.pdf"
   rm -f "${BEDPE_RESULT_FILE_FILTERED}_score_${circlizeScoreThreshold}_scaled.pdf"
 
   rm ${MERGED_DELEXTRACT}

--- a/resources/analysisTools/sophiaworkflow/sophiaAnnotateCoordinateCorrection.py
+++ b/resources/analysisTools/sophiaworkflow/sophiaAnnotateCoordinateCorrection.py
@@ -18,12 +18,12 @@
 
 from sys import argv
 
-righSideFile = argv[1]
+rightSideFile = argv[1]
 
-with open(righSideFile) as f:
+with open(rightSideFile) as f:
     for line in f:
         lineChunks = line.rstrip().split('\t')
-        geneMatches = ",".join(set(lineChunks[4].split(',')))
+        geneMatches = ",".join(sorted(list(set(lineChunks[4].split(',')))))
         lineIndices = set(lineChunks[3].split(','))
-        for index in lineIndices:
+        for index in sorted(list(lineIndices)):
             print("\t".join(lineChunks[0:3] + [index, geneMatches] + lineChunks[5:]))

--- a/resources/analysisTools/sophiaworkflow/tadIntersections.py
+++ b/resources/analysisTools/sophiaworkflow/tadIntersections.py
@@ -238,13 +238,13 @@ class BpDigitizer:
                     tmpGenes = set(chain(*res[1]))
                     if len(tmpGenes) > 1 and "." in tmpGenes:
                         tmpGenes.remove(".")
-                    genes = ','.join(tmpGenes)
+                    genes = ','.join(sorted(list(tmpGenes)))
                     if genes == "":
                         genes = "."
                     tmpCancerGenes = set(chain(*res[2]))
                     if len(tmpCancerGenes) > 1 and "." in tmpCancerGenes:
                         tmpCancerGenes.remove(".")
-                    cancerGenes = ','.join(tmpCancerGenes)
+                    cancerGenes = ','.join(sorted(list(tmpCancerGenes)))
                     if cancerGenes == "":
                         cancerGenes = "."
                     print("FALSE", indicesStr, genes, cancerGenes, sep='\t')

--- a/resources/analysisTools/sophiaworkflow/tadIntersections.py
+++ b/resources/analysisTools/sophiaworkflow/tadIntersections.py
@@ -137,8 +137,8 @@ class BpDigitizer:
                                     windowOccupancy[i + j] = True
         indices = [self.lineIndices[bpChr][i] for i, x in enumerate(windowOccupancy) if x]
         indicesStr = "."
-        genes = "."
-        cancerGenes = "."
+        genesStr = "."
+        cancerGenesStr = "."
         if not (lowQual or (np.sum(windowOccupancy) < 2 and exclusionCandidacy)):
             if exclusionCandidacy and bpPos2 - bpPos1 < 1000 and smallBorderHit:
                 indicesStr = ','.join([x + "*" for x in indices])
@@ -149,12 +149,12 @@ class BpDigitizer:
         tmpGenes = set(chain(*[[y.split(';')[0] for y in self.genes[bpChr][i]] for i, x in enumerate(windowOccupancy) if x]))
         if len(tmpGenes) > 1 and "." in tmpGenes:
             tmpGenes.remove(".")
-        genes = ','.join(tmpGenes)
+        genesStr = ','.join(sorted(list(tmpGenes)))
         tmpCancerGenes = set(chain(*[[y.split(';')[0] for y in self.cancerGenes[bpChr][i]] for i, x in enumerate(windowOccupancy) if x]))
         if len(tmpCancerGenes) > 1 and "." in tmpCancerGenes:
             tmpCancerGenes.remove(".")
-        cancerGenes = ','.join(tmpCancerGenes)
-        return [indicesStr, genes, cancerGenes]
+        cancerGenesStr = ','.join(sorted(list(tmpCancerGenes)))
+        return [indicesStr, genesStr, cancerGenesStr]
 
     def processBp(self, bpChr, bpPos):
         windowOccupancy = ((bpPos >= self.windowStarts[bpChr]) & (bpPos <= self.windowEnds[bpChr]))

--- a/resources/configurationFiles/sophiaAnalysis.xml
+++ b/resources/configurationFiles/sophiaAnalysis.xml
@@ -24,6 +24,7 @@
                cleanupScript="cleanupScript">
 
     <configurationvalues>
+        <cvalue name="DEBUG_SOPHIA" value="FALSE" description="Keep tempfiles if TRUE"/>
 
         <!-- Sample-specific parameter values -->
         <cvalue name="tumorMedianIsize" value="" description="Median insert size."/>

--- a/resources/configurationFiles/sophiaAnalysis.xml
+++ b/resources/configurationFiles/sophiaAnalysis.xml
@@ -139,7 +139,7 @@
         <tool name='tadannotationScript' value='tadIntersections.py' basepath="sophiaworkflow" />
         <tool name='decoyMapperScript' value="decoyMapper.py" basepath="sophiaworkflow"/>
         <tool name='dedupResultsScript' value='dedupResults.py' basepath="sophiaworkflow"/>
-        <tool name='safePaste' value="safe_pasty.py" basepath="sophiaworkflow"/>
+        <tool name='safePaste' value="safe_paste.py" basepath="sophiaworkflow"/>
         <!-- END NEW -->
 
         <tool name="circlizeScript" value="circlizeEvents.R" basepath="sophiaworkflow"/>

--- a/resources/configurationFiles/sophiaAnalysis.xml
+++ b/resources/configurationFiles/sophiaAnalysis.xml
@@ -139,6 +139,7 @@
         <tool name='tadannotationScript' value='tadIntersections.py' basepath="sophiaworkflow" />
         <tool name='decoyMapperScript' value="decoyMapper.py" basepath="sophiaworkflow"/>
         <tool name='dedupResultsScript' value='dedupResults.py' basepath="sophiaworkflow"/>
+        <tool name='safePaste' value="safe_pasty.py" basepath="sophiaworkflow"/>
         <!-- END NEW -->
 
         <tool name="circlizeScript" value="circlizeEvents.R" basepath="sophiaworkflow"/>


### PR DESCRIPTION
* Fix of a stupid bug introduced in 2.2.1
* Better protection against errors from sophia binary
* `DEBUG_SOPHIA` to turn off tempfile deletion
* `safe_paste.py` to fail early on inconsistent line-numbers in cut/cat/paste/script-code patch
* Few assertions on argument lists
* Some Python 3 type hints (for IntelliJ)
* Stabilization of output order of gene names to improve inter-version comparability
* Refactorings to make code more readable (and better express the expected value of table columns in scripts)

Will become 2.2.2. Fixes of problems with empty result sets are postponed to 2.2.3.